### PR TITLE
Fixing load error in Baseline

### DIFF
--- a/src/BaselineOfTheNoteTaker/BaselineOfTheNoteTaker.class.st
+++ b/src/BaselineOfTheNoteTaker/BaselineOfTheNoteTaker.class.st
@@ -87,7 +87,8 @@ BaselineOfTheNoteTaker >> postload: loader package: packageSpec [
 	"OSSubProcess spawns a process that is polling and it clashes with the automatic rewriting
 	so we kill it for now."
 	
-	((Process allInstances select: [ :p | p priority = 70 ]) select: [ :e | '*OSSub*' match: e name ]) first terminate
+	((Process allInstances select: [ :p | p priority = 70 ]) select: [ :e | '*OSSub*' match: e name ]) 
+		ifNotEmpty: [ : processArray | processArray first terminate ]
 ]
 
 { #category : 'baselines' }


### PR DESCRIPTION
This PR fixes a load error in the Baseline. When the process list is empty, the `first` raises a SubscriptOutOfBounds exception.
