### PR TITLE
Fix git executor hardcoded path

### DIFF
--- a/src/TheNoteTaker-UI/NTMDEditorPresenter.class.st
+++ b/src/TheNoteTaker-UI/NTMDEditorPresenter.class.st
@@ -79,6 +79,7 @@ NTMDEditorPresenter >> save: aText withExtension: anExtension [
 
 { #category : 'api' }
 NTMDEditorPresenter >> title [
+	"Answer a <String> representing the application name and selected note title"
 
 	^ String streamContents: [ : stream |
 		stream 

--- a/src/TheNoteTaker-UI/NTSpAddNoteCommand.class.st
+++ b/src/TheNoteTaker-UI/NTSpAddNoteCommand.class.st
@@ -38,7 +38,7 @@ NTSpAddNoteCommand >> execute [
 		label: 'Please provide the name of the new note';
 		openModalWithParent: context window.
 
-	(self isValidNoteTitle: answer) ifFalse: [ ^ self ].
+	(self isValidNoteName: answer) ifFalse: [ ^ self ].
 	newNote := self addNoteNamed: answer.
 	self context 
 		items: self facade notes;
@@ -46,8 +46,8 @@ NTSpAddNoteCommand >> execute [
 ]
 
 { #category : 'testing' }
-NTSpAddNoteCommand >> isValidNoteTitle: aString [ 
+NTSpAddNoteCommand >> isValidNoteName: aString [ 
 	"Answer <true> if aString is a valid note title"
 	
-	^ self application isValidNoteTitle: aString
+	^ self application isValidNoteName: aString
 ]

--- a/src/TheNoteTaker-UI/NTSpApplication.class.st
+++ b/src/TheNoteTaker-UI/NTSpApplication.class.st
@@ -66,10 +66,10 @@ NTSpApplication >> initialize [
 ]
 
 { #category : 'testing' }
-NTSpApplication >> isValidNoteTitle: aString [ 
+NTSpApplication >> isValidNoteName: aString [ 
 	"Answer <true> if aString is a valid note title"
 	
-	^ self noteTaker isValidNoteTitle: aString
+	^ self noteTaker isValidNoteName: aString
 ]
 
 { #category : 'accessig' }

--- a/src/TheNoteTaker-UI/NTSpImportFolderCommand.class.st
+++ b/src/TheNoteTaker-UI/NTSpImportFolderCommand.class.st
@@ -40,10 +40,10 @@ NTSpImportFolderCommand >> execute [
 ]
 
 { #category : 'testing' }
-NTSpImportFolderCommand >> isValidNoteTitle: aString [ 
+NTSpImportFolderCommand >> isValidNoteName: aString [ 
 	"Answer <true> if aString is a valid note title"
 	
-	^ self application isValidNoteTitle: aString
+	^ self application isValidNoteName: aString
 ]
 
 { #category : 'executing' }
@@ -52,7 +52,7 @@ NTSpImportFolderCommand >> processFolder: aFileReference [
 	aFileReference allFiles
 		"this test should be grouped somewhere else!"
 		select: [ :fileRef |  (#('md' 'txt' 'text') includes: fileRef extension asLowercase )
-										ifTrue: [ self isValidNoteTitle: fileRef contents ]
+										ifTrue: [ self isValidNoteName: fileRef contents ]
 										ifFalse: [ false ]]
 		thenDo: [ :fileRef | self addNoteFromFileReference: fileRef ]
 ]
@@ -63,7 +63,7 @@ NTSpImportFolderCommand >> processSelections: selections [
 	selections isEmptyOrNil
 		ifTrue: [ ^ self ].
 	selections
-		select: [ : selection | self isValidNoteTitle: selection asFileReference contents ]
+		select: [ : selection | self isValidNoteName: selection asFileReference contents ]
 		thenDo: [ : selection | self addNoteFromFileReference: selection asFileReference ]
 ]
 

--- a/src/TheNoteTaker-UI/NTSpImportNoteCommand.class.st
+++ b/src/TheNoteTaker-UI/NTSpImportNoteCommand.class.st
@@ -40,10 +40,10 @@ NTSpImportNoteCommand >> execute [
 ]
 
 { #category : 'testing' }
-NTSpImportNoteCommand >> isValidNoteTitle: aString [ 
+NTSpImportNoteCommand >> isValidNoteName: aString [ 
 	"Answer <true> if aString is a valid note title"
 	
-	^ self application isValidNoteTitle: aString
+	^ self application isValidNoteName: aString
 ]
 
 { #category : 'executing' }
@@ -52,7 +52,7 @@ NTSpImportNoteCommand >> processSelections: selections [
 	selections isEmptyOrNil
 		ifTrue: [ ^ self ].
 	selections
-		select: [ : selection | self isValidNoteTitle: selection asFileReference contents ]
+		select: [ : selection | self isValidNoteName: selection asFileReference contents ]
 		thenDo: [ : selection | self addNoteFromFileReference: selection asFileReference ]
 ]
 

--- a/src/TheNoteTaker-UI/NTSpSearchCreatePresenter.class.st
+++ b/src/TheNoteTaker-UI/NTSpSearchCreatePresenter.class.st
@@ -11,7 +11,8 @@ Class {
 	#instVars : [
 		'notesSearchCreateTextPresenter',
 		'notesSearchButtonPresenter',
-		'model'
+		'model',
+		'noteSettingsButtonPresenter'
 	],
 	#category : 'TheNoteTaker-UI-Core',
 	#package : 'TheNoteTaker-UI',
@@ -24,6 +25,7 @@ NTSpSearchCreatePresenter >> defaultLayout [
 	^ SpBoxLayout newLeftToRight
 		add: notesSearchCreateTextPresenter;
 		add: notesSearchButtonPresenter expand: false;
+		add: noteSettingsButtonPresenter expand: false;
 		yourself
 ]
 
@@ -52,9 +54,16 @@ NTSpSearchCreatePresenter >> initializePresenters [
 		yourself.
 	notesSearchButtonPresenter := self newButton
 		icon: (self iconNamed: #smallFind);
+		addStyle: 'small';		
 		action: [ self updateNotesList ];		
 		help: 'Search note';
-		yourself
+		yourself.
+	noteSettingsButtonPresenter := self newButton
+		icon: (self iconNamed: #smallConfiguration);
+		addStyle: 'small';		
+		action: [ self openTNTSettings ];
+		help: 'Settings';
+		yourself.
 ]
 
 { #category : 'accessing' }
@@ -75,6 +84,15 @@ NTSpSearchCreatePresenter >> notesList [
 	"Answer the <NTSpNoteIndexPresenter> responsible to display the notes"
 
 	^ self owner notesIndexPresenter
+]
+
+{ #category : 'initialization' }
+NTSpSearchCreatePresenter >> openTNTSettings [
+	
+	self flag: 'ToDo: To be updated when new settings browser takes place'.
+	SettingBrowser new
+		rootNodes: (SettingBrowser currentTree nodeNamed: #tnt) allChildren;
+		open
 ]
 
 { #category : 'callbacks' }

--- a/src/TheNoteTaker-UI/NTSpSearchCreatePresenter.class.st
+++ b/src/TheNoteTaker-UI/NTSpSearchCreatePresenter.class.st
@@ -83,7 +83,7 @@ NTSpSearchCreatePresenter >> requestNewNoteNamed: aString [
 	| newNote |
 	(self confirm: 'Do you want to create a new note named: ' , aString)
 		ifFalse: [ ^ self ].
-	(self model isValidNoteTitle: aString) 
+	(self model isValidNoteName: aString) 
 		ifFalse: [ ^ self ].
 
 	newNote := self application addNoteNamed: aString.

--- a/src/TheNoteTaker/NTGitExecutor.class.st
+++ b/src/TheNoteTaker/NTGitExecutor.class.st
@@ -4,25 +4,33 @@ I'm simple wrapper around git unix commands.
 Class {
 	#name : 'NTGitExecutor',
 	#superclass : 'Object',
-	#instVars : [
-		'projectPathString'
-	],
-	#category : 'TheNoteTaker',
-	#package : 'TheNoteTaker'
+	#category : 'TheNoteTaker-Utilities',
+	#package : 'TheNoteTaker',
+	#tag : 'Utilities'
 }
 
 { #category : 'adding' }
 NTGitExecutor >> add [
-	"I will avoid to hardcode path in the future"
 
-	LibC runCommand: self gitMinusCString , projectPathString , ' add ', projectPathString, '/*'
+	LibC runCommand: self gitMinusCString , self projectPathString , ' add ', self projectPathString , '/*'
 ]
 
 { #category : 'adding' }
 NTGitExecutor >> commit [
 
-	LibC runCommand: 'git -C /Users/ducasse/Workspace/FirstCircle/Writing/Working/researchnotes commit -m "saving"'.
+	LibC runCommand: self gitCommitCommand
 
+]
+
+{ #category : 'adding' }
+NTGitExecutor >> gitCommitCommand [
+	"Answer a <String> with a Git command to commit the current notes to a local folder"
+	
+	^ String streamContents: [ : stream |
+		stream
+			<< self gitMinusCString;
+			<< self projectPathString;
+			<< 'commit -m "saving"' ]
 ]
 
 { #category : 'adding' }
@@ -31,21 +39,21 @@ NTGitExecutor >> gitMinusCString [
 	^ 'git -C '
 ]
 
-{ #category : 'adding' }
-NTGitExecutor >> initialize [
-
-	super initialize.
-	projectPathString := '/Users/ducasse/Workspace/FirstCircle/Writing/Working/researchnotes'
-]
-
 { #category : 'accessing' }
-NTGitExecutor >> projectPathString: aString [
+NTGitExecutor >> projectPathString [
+	"Answer a <String> with a local or remote path where notes will be committed"
 
-	projectPathString := aString
+	^ self settingsClass projectPathString
 ]
 
 { #category : 'adding' }
 NTGitExecutor >> push [
 
-	LibC runCommand: self gitMinusCString , projectPathString , ' push'
+	LibC runCommand: self gitMinusCString , self projectPathString , ' push'
+]
+
+{ #category : 'initialization' }
+NTGitExecutor >> settingsClass [
+
+	^ NTSettings
 ]

--- a/src/TheNoteTaker/NTSettings.class.st
+++ b/src/TheNoteTaker/NTSettings.class.st
@@ -1,0 +1,44 @@
+"
+Class to manage The Note Taker settings.
+
+"
+Class {
+	#name : 'NTSettings',
+	#superclass : 'Object',
+	#classVars : [
+		'ProjectPathString'
+	],
+	#category : 'TheNoteTaker-Utilities',
+	#package : 'TheNoteTaker',
+	#tag : 'Utilities'
+}
+
+{ #category : 'accessing' }
+NTSettings class >> projectPathSettingsOn: aBuilder [
+	<systemsettings>
+
+	(aBuilder group: #tnt)
+		label: 'The Note Taker';
+		description: 'All TNT related settings';
+		noOrdering;
+		with: [
+			(aBuilder setting: #projectPathString)
+				label: 'Project Path' ;
+				ghostHelp: '/Users/ducasse/Workspace/FirstCircle/Writing/Working/researchnotes';
+				default: '';
+				description: 'Enter your local or remote path where notes will be committed. It can be empty']
+]
+
+{ #category : 'accessing' }
+NTSettings class >> projectPathString [
+	"Answer the preferred <String> where notes will be stored"
+
+	^ ProjectPathString
+]
+
+{ #category : 'accessing' }
+NTSettings class >> projectPathString: aString [
+	"Set the preferred <String> where notes will be stored"
+
+	ProjectPathString := aString
+]

--- a/src/TheNoteTaker/NTSingleton.class.st
+++ b/src/TheNoteTaker/NTSingleton.class.st
@@ -93,7 +93,7 @@ NTSingleton >> initialize [
 ]
 
 { #category : 'testing' }
-NTSingleton >> isValidNoteTitle: aString [ 
+NTSingleton >> isValidNoteName: aString [ 
 	"Answer <true> if aString is a valid note title, i.e. 
 		Non-empty, and not already present"
 

--- a/src/TheNoteTaker/NTSingleton.class.st
+++ b/src/TheNoteTaker/NTSingleton.class.st
@@ -99,7 +99,7 @@ NTSingleton >> isValidNoteName: aString [
 
 	(aString notNil and: [ aString notEmpty ])
 		ifTrue: [ ^ (self hasNoteNamed: aString trimBoth) not ].
-	self inform: 'Invalid note title: ' , aString.
+	self inform: 'Invalid note title'.
 	^ false
 ]
 


### PR DESCRIPTION
_Note: This PR also includes the changes in PR #21_

Remove hardcoding of the git path.
Access the git path string through a new NTSettings class, that holds TNT global settings.
Add a button to launch the TNT settings window.
Fix minor bugs when canceling new notes.
